### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/lib/src/discovery.dart
+++ b/lib/src/discovery.dart
@@ -316,7 +316,7 @@ class DiscoveredDevice {
     XmlDocument doc;
 
     try {
-      var content = await response.transform(utf8.decoder).join();
+      var content = await response.cast<List<int>>().transform(utf8.decoder).join();
       doc = xml.parse(content);
     } on Exception catch (e) {
       throw new FormatException(
@@ -380,7 +380,7 @@ class DiscoveredClient {
     XmlDocument doc;
 
     try {
-      var content = await response.transform(utf8.decoder).join();
+      var content = await response.cast<List<int>>().transform(utf8.decoder).join();
       doc = xml.parse(content);
     } on Exception catch (e) {
       throw new FormatException(

--- a/lib/src/service.dart
+++ b/lib/src/service.dart
@@ -55,7 +55,7 @@ class ServiceDescription {
     XmlElement doc;
 
     try {
-      var content = await response.transform(utf8.decoder).join();
+      var content = await response.cast<List<int>>().transform(utf8.decoder).join();
       content = content.replaceAll("\u00EF\u00BB\u00BF", "");
       doc = xml.parse(content).rootElement;
     } catch (e) {
@@ -147,7 +147,7 @@ class Service {
     request.write(body);
     var response = await request.close();
 
-    var content = await response.transform(utf8.decoder).join();
+    var content = await response.cast<List<int>>().transform(utf8.decoder).join();
 
     if (response.statusCode != 200) {
       try {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: upnp
-version: 2.0.0+1
+version: 2.0.0+2
 author: Kenneth Endfinger <kaendfinger@gmail.com>
 description: Universal Plugin and Play Host/Client
 homepage: https://github.com/SpinlockLabs/upnp.dart


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900